### PR TITLE
Add help message

### DIFF
--- a/cmd/unpack.go
+++ b/cmd/unpack.go
@@ -12,10 +12,11 @@ import (
 
 // unpackCmd represents the unpack command.
 var unpackCmd = &cobra.Command{
-	Use:  "unpack <src.png> [flags]",
-	Long: "Unpack sprite sheet image.",
-	Args: cobra.ExactArgs(1),
-	Run:  main,
+	Use:   "unpack <src.png> [flags]",
+	Short: "Unpack sprite sheet image",
+	Long:  "Unpack sprite sheet image",
+	Args:  cobra.ExactArgs(1),
+	Run:   main,
 }
 
 func init() {


### PR DESCRIPTION
Before

```sh
$ kaban -h
Kaban is a simple tool for manipulating sprite sheet images.

Usage:
  kaban [command]

Available Commands:
  help        Help about any command
  unpack

Flags:
  -h, --help      help for kaban
  -v, --version   version for kaban

Use "kaban [command] --help" for more information about a command.
```

After

```sh
$ kaban -h
Kaban is a simple tool for manipulating sprite sheet images.

Usage:
  kaban [command]

Available Commands:
  help        Help about any command
  unpack      Unpack sprite sheet image.

Flags:
  -h, --help      help for kaban
  -v, --version   version for kaban

Use "kaban [command] --help" for more information about a command.
```